### PR TITLE
Add vfs decorator and (some) tests

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -1,10 +1,17 @@
 const fp = require('fastify-plugin')
+const getDriver = require('./drivers/vfs.js')
 
 module.exports = fp(async function (app, opts, done) {
     const Driver = require('./drivers/' + app.config.driver.type)
-
     try {
-        app.decorate('driver', new Driver(app))
+        app.decorate('_driver', new Driver(app))
+        app.decorateRequest('vfs', null)
+        app.addHook('onRequest', (req, reply, done) => {
+            const teamId = req.params.teamId
+            const projectId = req.params.projectId
+            req.vfs = getDriver(app, app._driver, teamId, projectId)
+            done()
+        })
     } catch (err) {
         console.log(err)
     }

--- a/lib/drivers/localfs.js
+++ b/lib/drivers/localfs.js
@@ -1,19 +1,19 @@
 const fs = require('fs')
-const { join, isAbsolute, dirname } = require('path')
+const { join, isAbsolute, dirname, sep: pathSeparator } = require('path')
 
 const canary = 'ROOT_DIR_CANARY'
 
 function resolvePath (teamId, projectId, path) {
     let resolvedPath
-    if (path.startsWith('/')) {
+    if (path.startsWith(pathSeparator)) {
         resolvedPath = join(canary, teamId, path)
     } else {
         resolvedPath = join(canary, teamId, projectId, path)
     }
     if (resolvedPath.startsWith(canary)) {
-        const array = resolvedPath.split('/')
+        const array = resolvedPath.split(pathSeparator)
         array.shift()
-        resolvedPath = array.join('/')
+        resolvedPath = array.join(pathSeparator)
         return resolvedPath
     } else {
         throw Error('Invalid Path')
@@ -44,14 +44,18 @@ module.exports = function (app) {
         rootPath = app.config.driver.root
     }
 
-    console.log(app.config.driver.root)
-    console.log(rootPath)
+    // console.log(app.config.driver.root)
+    // console.log(rootPath)
 
     if (!fs.existsSync(rootPath)) {
         fs.mkdirSync(rootPath)
     }
 
     return {
+        get rootPath () {
+            return rootPath
+        },
+        resolvePath,
         async save (teamId, projectId, path, data) {
             const fullPath = join(rootPath, resolvePath(teamId, projectId, path))
             try {
@@ -61,6 +65,7 @@ module.exports = function (app) {
                 fs.writeFileSync(fullPath, data)
             } catch (err) {
                 console.log(err)
+                throw err
             }
         },
 
@@ -69,7 +74,7 @@ module.exports = function (app) {
             if (fs.existsSync(fullPath)) {
                 fs.appendFileSync(fullPath, data)
             } else {
-                this.save(teamId, projectId, path, data)
+                await this.save(teamId, projectId, path, data)
             }
         },
 

--- a/lib/drivers/memory.js
+++ b/lib/drivers/memory.js
@@ -1,20 +1,20 @@
 
-const { join } = require('path')
+const { join, sep: pathSeparator } = require('path')
 
 const canary = 'ROOT_DIR_CANARY'
 const storage = {}
 
 function resolvePath (teamId, projectId, path) {
     let resolvedPath
-    if (path.startsWith('/')) {
+    if (path.startsWith(pathSeparator)) {
         resolvedPath = join(canary, teamId, path)
     } else {
         resolvedPath = join(canary, teamId, projectId, path)
     }
     if (resolvedPath.startsWith(canary)) {
-        const array = resolvedPath.split('/')
+        const array = resolvedPath.split(pathSeparator)
         array.shift()
-        resolvedPath = array.join('/')
+        resolvedPath = array.join(pathSeparator)
         return resolvedPath
     } else {
         throw Error('Invalid Path')
@@ -23,6 +23,10 @@ function resolvePath (teamId, projectId, path) {
 
 module.exports = function (app) {
     return {
+        get rootPath () {
+            return ''
+        },
+        resolvePath,
         async save (teamId, projectId, path, data) {
             storage[resolvePath(teamId, projectId, path)] = data
         },
@@ -40,7 +44,7 @@ module.exports = function (app) {
         },
 
         async delete (teamId, projectId, path) {
-            console.log(resolvePath(teamId, projectId, path))
+            // console.log(resolvePath(teamId, projectId, path))
             delete storage[resolvePath(teamId, projectId, path)]
         },
 

--- a/lib/drivers/vfs.js
+++ b/lib/drivers/vfs.js
@@ -1,0 +1,29 @@
+module.exports = function (app, theDriver, teamId, projectId) {
+    return {
+        get rootPath () {
+            return theDriver.rootPath
+        },
+
+        resolvePath: theDriver.resolvePath,
+
+        async save (path, data) {
+            return await theDriver.save(teamId, projectId, path, data)
+        },
+
+        async append (path, data) {
+            return await theDriver.append(teamId, projectId, path, data)
+        },
+
+        async read (path) {
+            return await theDriver.read(teamId, projectId, path)
+        },
+
+        async delete (path) {
+            return await theDriver.delete(teamId, projectId, path)
+        },
+
+        async quota () {
+            return await theDriver.quota(teamId)
+        }
+    }
+}

--- a/lib/routes/files.js
+++ b/lib/routes/files.js
@@ -22,15 +22,12 @@ module.exports = async function (app, opts, done) {
     app.post('/:teamId/:projectId/*', {
 
     }, async (request, reply) => {
-        const teamId = request.params.teamId
-        const projectId = request.params.projectId
         const path = request.params['*']
-
         try {
             if (request.headers.ff_mode === 'append') {
-                await app.driver.append(teamId, projectId, path, request.body)
+                await request.vfs.append(path, request.body)
             } else {
-                await app.driver.save(teamId, projectId, path, request.body)
+                await request.vfs.save(path, request.body)
             }
             reply.code(200).send()
         } catch (err) {
@@ -58,12 +55,9 @@ module.exports = async function (app, opts, done) {
      * @memberof forge.fileserver.files
      */
     app.get('/:teamId/:projectId/*', async (request, reply) => {
-        const teamId = request.params.teamId
-        const projectId = request.params.projectId
         const path = request.params['*']
-
         try {
-            const file = await app.driver.read(teamId, projectId, path)
+            const file = await request.vfs.read(path)
             if (file) {
                 reply.send(file)
             } else {
@@ -83,10 +77,8 @@ module.exports = async function (app, opts, done) {
      * @memberof forge.fileserver.files
      */
     app.delete('/:teamId/:projectId/*', async (request, reply) => {
-        const teamId = request.params.teamId
-        const projectId = request.params.projectId
         const path = request.params['*']
-        await app.driver.delete(teamId, projectId, path)
+        await request.vfs.delete(path)
         reply.code(200).send()
     })
 

--- a/test/unit/drivers/localfs_spec.js
+++ b/test/unit/drivers/localfs_spec.js
@@ -1,0 +1,73 @@
+const should = require('should') // eslint-disable-line
+const setup = require('./setup.js')
+const fs = require('fs')
+const { join, sep: pathSeparator } = require('path')
+
+describe('localfs driver', function () {
+    let app
+    let teamId = 't1' // eslint-disable-line
+    let projectId = 'p1' // eslint-disable-line
+
+    beforeEach(async function () {
+        app = await setup({
+            home: 'var',
+            driver: {
+                type: 'localfs',
+                root: 'tmp'
+            }
+        }, {
+            teamId,
+            projectId
+        })
+    })
+
+    afterEach(async function () {
+        app.close()
+    })
+
+    it('creates driver', async function () {
+        const driver = app._driver
+        should(driver).be.an.Object()
+        driver.should.have.a.property('save').and.be.a.Function()
+        driver.should.have.a.property('read').and.be.a.Function()
+        driver.should.have.a.property('delete').and.be.a.Function()
+        driver.should.have.a.property('append').and.be.a.Function()
+        driver.should.have.a.property('quota').and.be.a.Function()
+    })
+    it('resolves a file path', async function () {
+        const driver = app._driver
+        const fileName = 'test1.txt'
+        const fileLocation = join(app.options.rootPath, driver.resolvePath(teamId, projectId, fileName))
+        const expectedLocation = `${app.options.rootPath}${pathSeparator}${teamId}${pathSeparator}${projectId}${pathSeparator}${fileName}`
+        // perform action
+        should(fileLocation).eql(expectedLocation)
+    })
+    it('saves text file', async function () {
+        const driver = app._driver
+        const fileName = 'test1.txt'
+        const fileLocation = join(app.options.rootPath, driver.resolvePath(teamId, projectId, fileName))
+
+        // pre-verify action
+        should(fs.existsSync(fileLocation)).be.false('File should not exist before test')
+        // perform action
+        await driver.save(teamId, projectId, fileName, 'this is test data')
+        // verify action
+        should(fs.existsSync(fileLocation)).be.true('File should exist after test')
+    })
+    it('saves text file in sub path', async function () {
+        const driver = app._driver
+        const fileName = join('sub1', 'sub2', 'test1.txt')
+        const fileLocation = join(app.options.rootPath, driver.resolvePath(teamId, projectId, fileName))
+        try {
+            fs.rmSync(fileLocation)
+        } catch (_error) {
+            // ignore
+        }
+        // pre-verify action
+        should(fs.existsSync(fileLocation)).be.false('File should not exist before test')
+        // perform action
+        await driver.save(teamId, projectId, fileName, 'this is test data')
+        // verify action
+        should(fs.existsSync(fileLocation)).be.true('File should exist after test')
+    })
+})

--- a/test/unit/drivers/memory_spec.js
+++ b/test/unit/drivers/memory_spec.js
@@ -1,0 +1,48 @@
+const should = require('should') // eslint-disable-line
+const setup = require('./setup.js')
+
+describe('memory driver', function () {
+    let app
+    let teamId = 't1' // eslint-disable-line
+    let projectId = 'p1' // eslint-disable-line
+
+    beforeEach(async function () {
+        app = await setup({
+            home: 'var',
+            driver: {
+                type: 'memory',
+                root: 'tmp'
+            }
+        }, {
+            teamId,
+            projectId
+        })
+    })
+
+    afterEach(async function () {
+        app.close()
+    })
+
+    it('creates driver', async function () {
+        const driver = app._driver
+        should(driver).be.an.Object()
+        driver.should.have.a.property('save').and.be.a.Function()
+        driver.should.have.a.property('read').and.be.a.Function()
+        driver.should.have.a.property('delete').and.be.a.Function()
+        driver.should.have.a.property('append').and.be.a.Function()
+        driver.should.have.a.property('quota').and.be.a.Function()
+    })
+    it('saves text file', async function () {
+        const driver = app._driver
+        const fileName = 'test1.txt'
+
+        // pre-verify action
+        // TODO: Need to be able to either driver.fileStat, driver.exists, or direct access to the storage object to test file does not exist
+
+        // perform action
+        await driver.save(teamId, projectId, fileName, 'this is a test')
+
+        // verify action
+        // TODO: Need to be able to either driver.fileStat, driver.exists, or direct access to the storage object to test file does not exist
+    })
+})

--- a/test/unit/drivers/setup.js
+++ b/test/unit/drivers/setup.js
@@ -1,0 +1,57 @@
+const fs = require('fs')
+const { join, isAbsolute, sep: pathSeparator } = require('path')
+const canary = 'ROOT_DIR_CANARY'
+
+function resolvePath (teamId, projectId, path) {
+    let resolvedPath
+    if (path.startsWith(pathSeparator)) {
+        resolvedPath = join(canary, teamId, path)
+    } else {
+        resolvedPath = join(canary, teamId, projectId, path)
+    }
+    if (resolvedPath.startsWith(canary)) {
+        const array = resolvedPath.split(pathSeparator)
+        array.shift()
+        resolvedPath = array.join(pathSeparator)
+        return resolvedPath
+    } else {
+        throw Error('Invalid Path')
+    }
+}
+
+module.exports = async function (config = {}, options = {}) {
+    const app = {
+        config: { ...config },
+        options: { ...options },
+        cleanUp: function (teamId, projectId) {
+            if (!app.config.driver.root || !app.options.rootPath) {
+                throw new Error('app.config.driver.root must be set')
+            }
+            app._driver.delete(teamId, projectId, 'test1.txt')
+            app._driver.delete(teamId, projectId, 'test2.txt')
+            app._driver.delete(teamId, projectId, 'test3.txt')
+        },
+        close: function () {
+            app.cleanUp(app.options.teamId, app.options.projectId)
+        }
+    }
+    let rootPath
+    if (!app.config.driver.root) {
+        throw new Error('app.config.driver.root must be set')
+    }
+    if (!isAbsolute(app.config.driver.root)) {
+        rootPath = join(app.config.home, app.config.driver.root)
+    } else {
+        rootPath = app.config.driver.root
+    }
+    if (app.config.driver.type === 'localfs') {
+        fs.mkdirSync(rootPath, { recursive: true })
+    }
+    const createDriver = require('../../../lib/drivers/' + app.config.driver.type)
+    app._driver = createDriver(app)
+
+    app.options.rootPath = rootPath
+    app.options.resolvePath = resolvePath
+    app.cleanUp(app.options.teamId, app.options.projectId)
+    return app
+}

--- a/test/unit/drivers/vfs_spec.js
+++ b/test/unit/drivers/vfs_spec.js
@@ -1,0 +1,151 @@
+const should = require('should') // eslint-disable-line
+const setup = require('./setup.js')
+const getDriver = require('../../../lib/drivers/vfs')
+const fs = require('fs')
+const { join, sep: pathSeparator } = require('path')
+
+describe('vfs driver', function () {
+    describe('memory driver', function () {
+        let app
+        let teamId = 't1' // eslint-disable-line
+        let projectId = 'p1' // eslint-disable-line
+        let vfs
+        beforeEach(async function () {
+            app = await setup({
+                home: 'var',
+                driver: {
+                    type: 'memory',
+                    root: 'tmp'
+                }
+            }, {
+                teamId,
+                projectId
+            })
+            vfs = getDriver(app, app._driver, teamId, projectId)
+        })
+
+        afterEach(async function () {
+            app.close()
+            vfs = null
+        })
+
+        it('creates driver', async function () {
+            should(vfs).be.an.Object()
+            vfs.should.have.a.property('rootPath')
+            vfs.should.have.a.property('resolvePath').and.be.a.Function()
+            vfs.should.have.a.property('save').and.be.a.Function()
+            vfs.should.have.a.property('read').and.be.a.Function()
+            vfs.should.have.a.property('delete').and.be.a.Function()
+            vfs.should.have.a.property('append').and.be.a.Function()
+            vfs.should.have.a.property('quota').and.be.a.Function()
+        })
+        it('saves text file', async function () {
+            const fileName = 'test1.txt'
+
+            // pre-verify action
+            const data1 = await vfs.read(fileName)
+            should(data1).be.Undefined()
+            // perform action
+            await vfs.save(fileName, 'this is a test')
+            // verify action
+            const data2 = await vfs.read(fileName)
+            should(data2).eql('this is a test')
+        })
+    })
+    describe('localfs driver', function () {
+        let app
+        let teamId = 't1' // eslint-disable-line
+        let projectId = 'p1' // eslint-disable-line
+        let vfs
+        beforeEach(async function () {
+            app = await setup({
+                home: 'var',
+                driver: {
+                    type: 'localfs',
+                    root: 'tmp'
+                }
+            }, {
+                teamId,
+                projectId
+            })
+            vfs = getDriver(app, app._driver, teamId, projectId)
+        })
+
+        afterEach(async function () {
+            app.close()
+            vfs = null
+        })
+
+        it('creates driver', async function () {
+            should(vfs).be.an.Object()
+            vfs.should.have.a.property('rootPath')
+            vfs.should.have.a.property('resolvePath').and.be.a.Function()
+            vfs.should.have.a.property('save').and.be.a.Function()
+            vfs.should.have.a.property('read').and.be.a.Function()
+            vfs.should.have.a.property('delete').and.be.a.Function()
+            vfs.should.have.a.property('append').and.be.a.Function()
+            vfs.should.have.a.property('quota').and.be.a.Function()
+        })
+        it('resolves a file path', async function () {
+            const fileName = 'test1.txt'
+            const fileLocation = join(app.options.rootPath, vfs.resolvePath(teamId, projectId, fileName))
+            const expectedLocation = `${app.options.rootPath}${pathSeparator}${teamId}${pathSeparator}${projectId}${pathSeparator}${fileName}`
+            // perform action
+            should(fileLocation).eql(expectedLocation)
+        })
+        it('saves text file', async function () {
+            const fileName = 'test1.txt'
+            const fileLocation = join(app.options.rootPath, vfs.resolvePath(teamId, projectId, fileName))
+
+            // pre-verify action
+            should(fs.existsSync(fileLocation)).be.false('File should not exist before test')
+            // perform action
+            await vfs.save(fileName, 'this is test data')
+            // verify action
+            should(fs.existsSync(fileLocation)).be.true('File should exist after test')
+        })
+        it('reads saved text file', async function () {
+            const fileName = 'test1.txt'
+            const fileLocation = join(app.options.rootPath, vfs.resolvePath(teamId, projectId, fileName))
+
+            // pre-verify action
+            should(fs.existsSync(fileLocation)).be.false('File should not exist before test')
+            // perform action
+            await vfs.save(fileName, 'this is test data to read back')
+            // verify action
+            const data = await vfs.read(fileName)
+            should(data.toString()).eql('this is test data to read back')
+        })
+        it('saves text file in sub path', async function () {
+            const fileName = join('sub1', 'sub2', 'test1.txt')
+            const fileLocation = join(app.options.rootPath, vfs.resolvePath(teamId, projectId, fileName))
+            try {
+                fs.rmSync(fileLocation)
+            } catch (_error) {
+                // ignore
+            }
+            // pre-verify action
+            should(fs.existsSync(fileLocation)).be.false('File should not exist before test')
+            // perform action
+            await vfs.save(fileName, 'this is test data')
+            // verify action
+            should(fs.existsSync(fileLocation)).be.true('File should exist after test')
+        })
+        it('reads text file in sub path', async function () {
+            const fileName = join('sub1', 'sub2', 'test1.txt')
+            const fileLocation = join(app.options.rootPath, vfs.resolvePath(teamId, projectId, fileName))
+            try {
+                fs.rmSync(fileLocation)
+            } catch (_error) {
+                // ignore
+            }
+            // pre-verify action
+            should(fs.existsSync(fileLocation)).be.false('File should not exist before test')
+            // perform action
+            await vfs.save(fileName, 'this is more but different test data')
+            // verify action
+            const data = await vfs.read(fileName)
+            should(data.toString()).eql('this is more but different test data')
+        })
+    })
+})


### PR DESCRIPTION
Ben, I abstracted an interface (called `vfs`) that simplifies calls to the driver (be that the localfs/memory/future drivers)

The `request` object now gets decorated with a `vfs` property so no need to send `teamId` and `projectId` with every call to the driver functions.

The point of the vfs interface is to ensure we implement all the necessary calls and to provide a seamless interface.

I had to add 2 properties to the drivers' object so that we can achieve this arrangement.

There may better be a way to implement this - I depend on your judgement.

It would be good if we can catch up on this asap.

Ta.