### PR TITLE
Add units parser for the quota

### DIFF
--- a/forge/config.js
+++ b/forge/config.js
@@ -2,6 +2,7 @@
 const fs = require('fs')
 const fp = require('fastify-plugin')
 const path = require('path')
+const xbytes = require('xbytes')
 const YAML = require('yaml')
 
 module.exports = fp(async function (app, opts, next) {
@@ -85,6 +86,16 @@ module.exports = fp(async function (app, opts, next) {
         if (!config.logging.http) {
             config.logging.http = 'warn'
         }
+    }
+
+    if (config.driver?.quota) {
+        const parsed = xbytes.parse(config.driver.quota)
+        config.driver.quota = parsed.bytes
+    }
+
+    if (config.context?.quota) {
+        const parsed = xbytes.parse(config.context.quota)
+        config.context.quota = parsed.bytes
     }
     Object.freeze(config)
     app.decorate('config', config)

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "semver": "^7.3.8",
     "sequelize": "^6.25.3",
     "sqlite3": "^5.1.2",
+    "xbytes": "^1.8.0",
     "yaml": "^2.1.3"
   },
   "devDependencies": {


### PR DESCRIPTION
At the moment quota's are specified in bytes, this PR allows units to be used

It uses the [xbytes](https://www.npmjs.com/package/xbytes?activeTab=readme) package with the following suffixes:

Index | Prefix | Decimal Bits | Binary Bits (IEC) | Decimal Bytes | Binary Bytes (IEC)
-- | -- | -- | -- | -- | --
0 | - | b (Bits) | b (Bits) | b (Bits) | b (Bits)
0 | - | B (Bytes) | B (Bytes) | B (Bytes) | B (Bytes)
1 | K | Kb (KiloBits) | Kib (KiloBits) | KB (KiloBytes) | KiB (KibiBytes)
2 | M | Mb (MegaBits) | Mib (MebiBits) | MB (MegaBytes) | MiB (MebiBytes)
3 | G | Gb (GigaBits) | Gib (GibiBits) | GB (GigaBytes) | GiB (GibiBytes)
4 | T | Tb (TeraBits) | Tib (TebiBits) | TB (TeraBytes) | TiB (TebiBytes)
5 | P | Pb (PetaBits) | Pib (PebiBits) | PB (PetaBytes) | PiB (PebiBytes)
6 | E | Eb (ExaBits) | Eib (ExbiBits) | EB (ExaBytes) | EiB (ExbiBytes)
7 | Z | Zb (ZettaBits) | Zib (ZebiBits) | ZB (ZettaBytes) | ZiB (ZebiBytes)
8 | Y | Yb (YottaBits) | Yib (YobiBits) | YB (YottaBytes) | YiB (YobiBytes)

