### PR TITLE
Fix run serve

### DIFF
--- a/forge/config.js
+++ b/forge/config.js
@@ -15,7 +15,7 @@ module.exports = {
             process.env.FLOWFORGE_HOME = process.cwd()
         } else if (!process.env.FLOWFORGE_HOME) {
             if (process.env.NODE_ENV === 'development') {
-                process.env.FLOWFORGE_HOME = path.resolve(__dirname, '../..')
+                process.env.FLOWFORGE_HOME = path.resolve(__dirname, '..')
             } else {
                 process.env.FLOWFORGE_HOME = process.cwd()
                 if (fs.existsSync('/opt/flowforge-file-storage')) {


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail -->
code taken from forge app (in #82 ) has an extra depth of dir to remove when running with `npm run serve`. file-server only has one.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

