### PR TITLE
Fix starup log to print file-server version

### DIFF
--- a/forge/config.js
+++ b/forge/config.js
@@ -81,7 +81,7 @@ module.exports = {
         if (process.env.NODE_ENV === 'development') {
             app.log.info('Development mode')
         }
-        app.log.info(`FlowFuse File Storage v${config.ffVersion}`)
+        app.log.info(`FlowFuse File Storage v${config.version}`)
         app.log.info(`FlowFuse File Storage running with NodeJS ${process.version}`)
         app.log.info(`FlowFuse File Storage HOME Directory: ${process.env.FLOWFORGE_HOME}`)
         if (!opts.config) {


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail -->
current log prints `vundefined` at startup

```
[2025-03-05T11:28:40.278Z] INFO: Development mode
[2025-03-05T11:28:40.278Z] INFO: FlowFuse File Storage vundefined
[2025-03-05T11:28:40.278Z] INFO: FlowFuse File Storage running with NodeJS v18.17.1
```

