### PR TITLE
PostgreSQL returning string for used quota size

### DIFF
--- a/forge/context-driver/sequelize.js
+++ b/forge/context-driver/sequelize.js
@@ -151,6 +151,8 @@ module.exports = {
                     // only calculate the current size if we are going to need it
                     if (changeSize >= 0) {
                         const currentSize = await this.quota(instanceId)
+                        console.log('currentSize', currentSize, typeof currentSize)
+                        console.log(`${currentSize} ${changeSize} ${currentSize + changeSize}`, (currentSize + changeSize))
                         if (currentSize + changeSize > quotaLimit) {
                             app.log.warn(`context quota check fail: ${instanceId}/${scope} current=${currentSize} delta=${changeSize} limit=${quotaLimit} requested=${currentSize + changeSize}`)
                             const err = new Error('Over Quota')

--- a/forge/context-driver/sequelize.js
+++ b/forge/context-driver/sequelize.js
@@ -150,7 +150,7 @@ module.exports = {
                     }
                     // only calculate the current size if we are going to need it
                     if (changeSize >= 0) {
-                        const currentSize = await this.quota(instanceId)
+                        const currentSize = Number.parseInt(await this.quota(instanceId))
                         console.log('currentSize', currentSize, typeof currentSize)
                         console.log(`${currentSize} ${changeSize} ${currentSize + changeSize}`, (currentSize + changeSize))
                         if (currentSize + changeSize > quotaLimit) {

--- a/forge/context-driver/sequelize.js
+++ b/forge/context-driver/sequelize.js
@@ -151,8 +151,6 @@ module.exports = {
                     // only calculate the current size if we are going to need it
                     if (changeSize >= 0) {
                         const currentSize = Number.parseInt(await this.quota(instanceId))
-                        console.log('currentSize', currentSize, typeof currentSize)
-                        console.log(`${currentSize} ${changeSize} ${currentSize + changeSize}`, (currentSize + changeSize))
                         if (currentSize + changeSize > quotaLimit) {
                             app.log.warn(`context quota check fail: ${instanceId}/${scope} current=${currentSize} delta=${changeSize} limit=${quotaLimit} requested=${currentSize + changeSize}`)
                             const err = new Error('Over Quota')


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail -->
When using a PostgreSQL database the quota check is returning a String not a integer

This results in a string concatenation rather than addition

e.g.

```
const quota = "1234"
const changeSize = 5
quota + changeSize = "12345" not 1239
```


## Related Issue(s)

<!-- What issue does this PR relate to? -->
Discovered while looking at logs on a customer call.

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

