### PR TITLE
Rename context driver to `db` from `sequelize`

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ options.
 
 ### Context Storage
 
-#### Sequelize
+#### Database
 
 This driver can use either PostgreSQL or SQLite to hold context values.
 
@@ -173,7 +173,7 @@ To use with PostgreSQL configure as follows:
 
 ```yaml
 context:
-  type: sequelize
+  type: db
   options:
     type: postgres
     host: 127.0.0.1
@@ -188,7 +188,7 @@ To use with SQLite configure as follows:
 
 ```yaml
 context:
-  type: sequelize
+  type: db
   options:
     type: sqlite
     storage: ff-context.db

--- a/forge/routes/context.js
+++ b/forge/routes/context.js
@@ -10,7 +10,12 @@
 /** @typedef {import('fastify').FastifyRequest} FastifyRequest */
 
 module.exports = async function (app, opts) {
-    const driver = require(`../context-driver/${app.config.context.type}`)
+    let driver
+    if (app.config.context.type === 'db') {
+        driver = require(`../context-driver/sequelize`)
+    } else {
+        driver = require(`../context-driver/${app.config.context.type}`)
+    }
 
     await driver.init(app)
 


### PR DESCRIPTION
closes #45

## Description

<!-- Describe your changes in detail -->
Legacy clean up of old issues

Renames the context.type from `sequelize` to `db`. Basically just adds a alias so as not to break current standard install on upgrade.

## Related Issue(s)

<!-- What issue does this PR relate to? -->
#45

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

